### PR TITLE
remove the page on API Developers List because it doesn;t work at all

### DIFF
--- a/topics/api-reference/api-reference.md
+++ b/topics/api-reference/api-reference.md
@@ -17,8 +17,6 @@ This section covers:
 
 * [Maven Interface](maven-interface.md)
 
-* [Plugin Developers List API](plugin-developers-list.md)
-
 * [Plugin Repository REST Client](plugin-repository-rest-client.md)
 
 * [Check License API](check-license.md)


### PR DESCRIPTION
+ removed the chapters about moderator and marketplace admin roles as they don't have to be public